### PR TITLE
Allow initialCheck to run if called after DOM is already ready

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = tab
+indent_size = 2

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Or it can be an array, containing an element:
 
 - `['within 100px of', el]` (again, "of" will be removed)
 
-The optional third argument (which defaults to false) will check immediately (or as soon as the page has loaded)
+The optional third argument (which defaults to false) will check immediately (or as soon as the page is ready)
 whether the scroll pattern is true, instead of waiting for the user to scroll.
 This is good for something like a lazy loading library where stuff could be on
 screen initially.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Or it can be an array, containing an element:
 
 - `['within 100px of', el]` (again, "of" will be removed)
 
-The optional third argument (which defaults to false) will check immediately (or once the page has loaded)
+The optional third argument (which defaults to false) will check immediately (or as soon as the page has loaded)
 whether the scroll pattern is true, instead of waiting for the user to scroll.
 This is good for something like a lazy loading library where stuff could be on
 screen initially.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Or it can be an array, containing an element:
 
 - `['within 100px of', el]` (again, "of" will be removed)
 
-The optional third argument (which defaults to false) will check on page load
+The optional third argument (which defaults to false) will check immediately (or once the page has loaded)
 whether the scroll pattern is true, instead of waiting for the user to scroll.
 This is good for something like a lazy loading library where stuff could be on
 screen initially.

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "gulp": "^3.8.11",
     "lmn-gulp-tasks": "^1.3.6",
     "mocha": "^2.2.1",
-    "should": "^5.2.0"
+    "should": "^5.2.0",
+    "sinon": "^1.17.5"
   },
   "dependencies": {
     "fix-ev": "^0.1.1"

--- a/src/when-scroll.js
+++ b/src/when-scroll.js
@@ -20,8 +20,12 @@ function whenScroll(scrollPattern, cb, initialCheck) {
 
 	util.on('scroll', window, scrollHandler);
 
-	if (initialCheck) {
-		util.on('DOMContentLoaded', document, scrollHandler);
+  if (initialCheck) {
+		if (document.readyState === 'interactive' || document.readyState === 'complete') {
+			scrollHandler();
+		} else {
+			util.on('DOMContentLoaded', document, scrollHandler);
+		}
 	}
 
 	function scrollHandler() {

--- a/src/when-scroll.js
+++ b/src/when-scroll.js
@@ -20,7 +20,7 @@ function whenScroll(scrollPattern, cb, initialCheck) {
 
 	util.on('scroll', window, scrollHandler);
 
-  if (initialCheck) {
+	if (initialCheck) {
 		if (document.readyState === 'interactive' || document.readyState === 'complete') {
 			scrollHandler();
 		} else {

--- a/test/_setup.js
+++ b/test/_setup.js
@@ -1,6 +1,6 @@
 'use strict';
 
-global.window = {};
+global.window = { location: {} };
 
 global.fakeElement = function () {
 	var el = {};

--- a/test/when-scroll.spec.js
+++ b/test/when-scroll.spec.js
@@ -6,26 +6,26 @@ var util = require('../src/util');
 // This definitely only works client-side
 global.window = {};
 global.document = {
-  documentElement: { scrollTop: 0 },
-  readyState: 'loading'
+	documentElement: { scrollTop: 0 },
+	readyState: 'loading'
 };
 var whenScroll = require('../src/when-scroll');
 
 describe('when-scroll main function', function () {
 	var triggerScroll;
-  var triggerLoad;
+	var triggerLoad;
 
 	before(function () {
 		util.on = function (event, el, cb) {
-      switch (event) {
-        case 'scroll':
-          triggerScroll = function (scrollTop) {
-    				document.documentElement.scrollTop = scrollTop;
-    				cb();
-    			};
-        case 'DOMContentLoaded':
-          triggerLoad = cb;
-      }
+			switch (event) {
+				case 'scroll':
+					triggerScroll = function (scrollTop) {
+						document.documentElement.scrollTop = scrollTop;
+						cb();
+					};
+				case 'DOMContentLoaded':
+					triggerLoad = cb;
+			}
 		};
 	});
 
@@ -47,34 +47,34 @@ describe('when-scroll main function', function () {
 		triggerScroll(700);
 	});
 
-  it('should only run when a scroll event occurs', function () {
-    var cb = sinon.spy();
-    triggerScroll(400);
-    whenScroll('below 300px', cb);
-    triggerScroll(400);
-    cb.calledOnce.should.be.True;
-  });
+	it('should only run when a scroll event occurs', function () {
+		var cb = sinon.spy();
+		triggerScroll(400);
+		whenScroll('below 300px', cb);
+		triggerScroll(400);
+		cb.calledOnce.should.be.True;
+	});
 
-  it('should run once DOM is loaded if initialCheck is supplied', function () {
-    var cb = sinon.spy();
-    whenScroll('below 300px', cb, true);
-    triggerLoad();
-    cb.calledOnce.should.be.True;
-  });
+	it('should run once DOM is loaded if initialCheck is supplied', function () {
+		var cb = sinon.spy();
+		whenScroll('below 300px', cb, true);
+		triggerLoad();
+		cb.calledOnce.should.be.True;
+	});
 
-  it('should run immediatley if initialCheck is supplied and DOM readyState is interative', function () {
-    global.document.readyState = 'interactive';
-    var cb = sinon.spy();
-    triggerScroll(400);
-    whenScroll('below 300px', cb, true);
-    cb.calledOnce.should.be.True;
-  });
+	it('should run immediatley if initialCheck is supplied and DOM readyState is interative', function () {
+		global.document.readyState = 'interactive';
+		var cb = sinon.spy();
+		triggerScroll(400);
+		whenScroll('below 300px', cb, true);
+		cb.calledOnce.should.be.True;
+	});
 
-  it('should run immediatley if initialCheck is supplied and DOM readyState is complete', function () {
-    global.document.readyState = 'complete';
-    var cb = sinon.spy();
-    triggerScroll(400);
-    whenScroll('below 300px', cb, true);
-    cb.calledOnce.should.be.True;
-  });
+	it('should run immediatley if initialCheck is supplied and DOM readyState is complete', function () {
+		global.document.readyState = 'complete';
+		var cb = sinon.spy();
+		triggerScroll(400);
+		whenScroll('below 300px', cb, true);
+		cb.calledOnce.should.be.True;
+	});
 });

--- a/test/when-scroll.spec.js
+++ b/test/when-scroll.spec.js
@@ -1,21 +1,31 @@
 'use strict';
 
+var sinon = require('sinon');
 var util = require('../src/util');
 
 // This definitely only works client-side
 global.window = {};
-global.document = { documentElement: { scrollTop: 0 }};
+global.document = {
+  documentElement: { scrollTop: 0 },
+  readyState: 'loading'
+};
 var whenScroll = require('../src/when-scroll');
 
 describe('when-scroll main function', function () {
 	var triggerScroll;
+  var triggerLoad;
 
 	before(function () {
 		util.on = function (event, el, cb) {
-			triggerScroll = function (scrollTop) {
-				document.documentElement.scrollTop = scrollTop;
-				cb();
-			};
+      switch (event) {
+        case 'scroll':
+          triggerScroll = function (scrollTop) {
+    				document.documentElement.scrollTop = scrollTop;
+    				cb();
+    			};
+        case 'DOMContentLoaded':
+          triggerLoad = cb;
+      }
 		};
 	});
 
@@ -36,4 +46,35 @@ describe('when-scroll main function', function () {
 		triggerScroll(600);
 		triggerScroll(700);
 	});
+
+  it('should only run when a scroll event occurs', function () {
+    var cb = sinon.spy();
+    triggerScroll(400);
+    whenScroll('below 300px', cb);
+    triggerScroll(400);
+    cb.calledOnce.should.be.True;
+  });
+
+  it('should run once DOM is loaded if initialCheck is supplied', function () {
+    var cb = sinon.spy();
+    whenScroll('below 300px', cb, true);
+    triggerLoad();
+    cb.calledOnce.should.be.True;
+  });
+
+  it('should run immediatley if initialCheck is supplied and DOM readyState is interative', function () {
+    global.document.readyState = 'interactive';
+    var cb = sinon.spy();
+    triggerScroll(400);
+    whenScroll('below 300px', cb, true);
+    cb.calledOnce.should.be.True;
+  });
+
+  it('should run immediatley if initialCheck is supplied and DOM readyState is complete', function () {
+    global.document.readyState = 'complete';
+    var cb = sinon.spy();
+    triggerScroll(400);
+    whenScroll('below 300px', cb, true);
+    cb.calledOnce.should.be.True;
+  });
 });


### PR DESCRIPTION
Runs the scroll handler if initialCheck supplied and DOM is ready.

Resolves #3.
